### PR TITLE
Fix links when inside iframe

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
+  <base target="_parent">
   <title>Co-Habitat</title>
   <meta name="author" content="">
   <meta name="description" content="">


### PR DESCRIPTION
Links inside an iframe open in the iframe, but they should open in the parent.

Concerned are the links in the bottom right corner.